### PR TITLE
Changed color and line thickness in bin/cnv2bed.pl

### DIFF
--- a/bin/cnv2bed.pl
+++ b/bin/cnv2bed.pl
@@ -38,8 +38,8 @@ if( defined($opt{cnv}) ){
             if( $row =~/END=(\d+);/ ){ $end = $1; }
             if( $row =~/RankScore=$opt{pb}:([\d-]+);/ ){ $score = $1; next if( $score <= $SCORE ); }
             if( $row =~/RankResult=([\d-]+)\|/ ){ $rank = $1; }
-            if( $svtype =~/DEL/ ){ $color = '204,0,0'; }elsif( $svtype =~/DUP/ ){ $color = '0,64,255'; }
-            print "chr$cols[0]\t".( $cols[1] - 1 )."\t$end\t\"$svtype,score=$score\"\t0\t+\t".( $cols[1] - 1 )."\t$end\t$color\n";
+            if( $svtype =~/DEL/ ){ $color = '204,0,0'; }elsif( $svtype =~/DUP/ ){ $color = '0,0,153'; }
+            print "chr$cols[0]\t".( $cols[1] - 1 )."\t$end\t\"$svtype,score=$score\"\t0\t\.\t0\t0\t$color\n";
         }
     } close VCF;
 }


### PR DESCRIPTION
Changes color code from rgb(0,64,255) to rgb(0,0,153) and also removes features thickStart, thickEnd and strand orientation. Changes are made to accommodate a better visualisation in ChAS. 