### PR TITLE
if vcf of _fa or _ma is used then the resulting bed wont be affected

### DIFF
--- a/bin/cnv2bed.pl
+++ b/bin/cnv2bed.pl
@@ -36,7 +36,7 @@ if( defined($opt{cnv}) ){
             next if( $cols[ $labels{ $opt{pb} } ] =~/^\.\// );
             if( $row =~/SVTYPE=(\w+);/ ) { $svtype = $1; next if( $svtype eq 'BND' ); }
             if( $row =~/END=(\d+);/ ){ $end = $1; }
-            if( $row =~/RankScore=$opt{pb}:([\d-]+);/ ){ $score = $1; next if( $score <= $SCORE ); }
+            if( $row =~/RankScore=$opt{pb}\S{0,3}:([\d-]+);/ ){ $score = $1; next if( $score <= $SCORE ); }
             if( $row =~/RankResult=([\d-]+)\|/ ){ $rank = $1; }
             if( $svtype =~/DEL/ ){ $color = '204,0,0'; }elsif( $svtype =~/DUP/ ){ $color = '0,0,153'; }
             print "chr$cols[0]\t".( $cols[1] - 1 )."\t$end\t\"$svtype,score=$score\"\t0\t\.\t0\t0\t$color\n";


### PR DESCRIPTION
Verkade som att processen **svvcf_to_bed** gavs _fa.sv.scored.sorted.vcf.gz som input för ett av fallen (8555-22) och perl-skriptet fallerade då på att plocka ut RankScore eftersom den matchade mot gruppnamnet (8555-22_fa). La till ett villkor i matchningen så att det inte ska spela någon roll ifall affected -filerna används för uppgiften.