### PR TITLE
tool to update bed-file with new ensembl builds and clinvar-updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ work/
 git.hash
 todo
 mito_full.nf
+## ref tools
+bin/reference_tools/*.log
+bin/reference_tools/*.bed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG
+
+### 3.4.0
+#### new features
+- added a script to update wgs-bed file with current clinvar intron + intergenic regions. Also produces a log file of what's been added and removed
+- added support to dry run vcf for testing scoring
+
 ### 3.3.3
 #### minor improvements
 - merged cnv2bed branch, small updates to color scheme for Alamut import files for CNVs

--- a/bin/reference_tools/update_bed.pl
+++ b/bin/reference_tools/update_bed.pl
@@ -1,0 +1,279 @@
+#!/usr/bin/perl -w
+use strict;
+use Data::Dumper;
+use File::Basename;
+use lib dirname (__FILE__);
+use vcf2 qw( parse_vcf );
+use Getopt::Long;
+
+my %opt = ();
+GetOptions( \%opt, 'old=s', 'new=s', 'build=s', 'clinvardate=s' );
+
+### Logic ###
+# have a baseline bed that defines exonic regions, padded with 20(?) bp
+# read clinvar vcf (likely pathogenic + pathogenic), convert it to bed, intersect. Regions not in baseline padded (5 bp?) and merge
+
+#my $clinvar_vcf = "/fs1/resources/ref/hg38/annotation_dbs/bedupdatertest/new_chrom8.vcf"; 
+#my $clinvar_vcf_old = "/fs1/resources/ref/hg38/annotation_dbs/bedupdatertest/old_chrom8.vcf";
+#my $clinvar_vcf = "/fs1/resources/ref/hg38/annotation_dbs/clinvar38_latest.vcf.gz";
+#my $clinvar_vcf_old = "/data/bnf/ref/annotations_dbs/clinvar38_20200106.vcf.gz";
+my $clinvar_vcf = $opt{'new'};
+my $clinvar_vcf_old = $opt{'old'};
+my $agilent = "agilient_hg38_nochr_noalt_1-3.bed";
+
+### BASE BED ########
+my $release = $opt{'build'}; # as argument
+my $gtf = "Homo_sapiens.GRCh38.".$release.".gtf.gz"; 
+my $gtf_request = "https://ftp.ensembl.org/pub/release-".$release."/gtf/homo_sapiens/$gtf";
+my $base_bed = "exons_hg38_".$release.".bed";
+## fetch $release from ensembl and get all exons for coding genes 
+get_base($gtf_request,$gtf,$base_bed,$release);
+
+### BED TO ADD DATA TO ###
+my $clinvar = $opt{'clinvardate'}; # as argument
+my $final_bed = "exons_".$release."padded20bp_clinvar-".$clinvar."padded5bp."."bed";  # final name of bed, will concat to this
+
+# if recreating same clinvarversion and ensembl build, delete old so it wont be concatenated
+if(-e $final_bed) {
+    unlink($final_bed);
+}
+
+
+
+## ADD DATA ##
+add_to_bed($final_bed,$base_bed,"EXONS-$release");
+add_to_bed($final_bed,$agilent,"AGILENT-EXOME");
+
+## clinvar variants ##
+my ($clinvar_new,$new_benign) = read_clinvar($clinvar_vcf);
+my ($clinvar_old,$old_benign) = read_clinvar($clinvar_vcf_old);
+my %old_benign = %$old_benign;
+my %new_benign = %$new_benign;
+my ($newtoadd,$oldtoremove) = compare_clinvar($clinvar_new,$clinvar_old,$final_bed);
+my $clinvarlog = "clinvar_".$clinvar.".log";
+my $clinvar_final_bed = "clinvar_".$clinvar.".bed";
+if (-e $clinvarlog) { unlink( $clinvarlog ); }
+if (-e $clinvar_final_bed) { unlink( $clinvar_final_bed ); }
+clinvar_bed_andinfo($newtoadd,"new",$clinvarlog);
+clinvar_bed_andinfo($oldtoremove,"old",$clinvarlog);
+clinvar_bed_andinfo($newtoadd,"bed",$clinvar_final_bed);
+add_to_bed($final_bed,$clinvar_final_bed,".");
+## SORT MERGE ###
+sort_merge($final_bed);
+
+## takes clinvar-vcf saves pathogenicity status, returns one hash with important variants
+## and one with benign
+sub read_clinvar {
+    my $vcf = shift;
+    my $vcf_hash = CMD::vcf2->new('file'=>$vcf );
+    my %clinvar_variants;
+    my %benign_clinvar_variants;
+    my $clinvar_bed = "clinvar.bed";
+    ## save all variants that is marked as Pathogenic in some way
+    while ( my $var = $vcf_hash->next_var() ) {
+        my $sig = ""; my $confidence = "";
+        my $haplo = "";
+        if ($var->{INFO}->{CLNSIG}) {
+            $sig = $var->{INFO}->{CLNSIG};
+        }
+        if ($var->{INFO}->{CLNSIGINCL}) {
+            $haplo = $var->{INFO}->{CLNSIGINCL};
+        }
+        if ($var->{INFO}->{CLNSIGCONF}) {
+            $confidence = $var->{INFO}->{CLNSIGCONF};
+        }        
+        next if ($sig eq "" && $haplo);
+        my $keep = 0;
+        my $reason = "";
+        if ( $sig =~ /Pathogenic/ || $sig =~ /Likely_pathogenic/ ) {
+            $keep = 1;
+            $reason = $sig;
+        }
+        elsif ( $sig =~ /Conflicting_interpretations_of_pathogenicity/ ) {
+            if ( $confidence =~ /Pathogenic/ || $confidence =~ /Likely_pathogenic/ ) {
+                $keep = 1;
+                $reason = $confidence;
+            }
+        }
+        elsif ( $haplo =~ /athogenic/ ) {
+            $keep = 1;
+            $reason = $haplo;
+        }
+
+
+        if ($keep) {
+            next if ($var->{CHROM} eq "MT");
+            $clinvar_variants{$var->{CHROM}.":".$var->{POS}."_".$var->{REF}."_".$var->{ALT}}{INFO} = $var->{INFO};
+            $clinvar_variants{$var->{CHROM}.":".$var->{POS}."_".$var->{REF}."_".$var->{ALT}}{CHROM} = $var->{CHROM};
+            $clinvar_variants{$var->{CHROM}.":".$var->{POS}."_".$var->{REF}."_".$var->{ALT}}{POS} = $var->{POS};
+            $clinvar_variants{$var->{CHROM}.":".$var->{POS}."_".$var->{REF}."_".$var->{ALT}}{REASON} = $reason;
+
+        }
+        else {
+            $benign_clinvar_variants{$var->{CHROM}.":".$var->{POS}."_".$var->{REF}."_".$var->{ALT}}{INFO} = $var->{INFO};
+            $benign_clinvar_variants{$var->{CHROM}.":".$var->{POS}."_".$var->{REF}."_".$var->{ALT}}{REASON} = $reason;
+        }
+    }
+    return \%clinvar_variants,\%benign_clinvar_variants;
+}
+
+## fetches $release ensembl gtf and returns bed with coding genes exons
+sub get_base {
+    my $gtf_req = shift;
+    my $gtf = shift;
+    my $base = shift;
+    my $release = shift;
+    system("wget $gtf_req -O tmp.gtf.gz");
+    system("gunzip tmp.gtf.gz");
+    open(BASE,'>',$base);
+    open(GTF, "tmp.gtf");
+    my $keep = 0;
+    while(<GTF>) {
+        chomp;
+        next if /^#/;
+        my @g =split /\t/;
+        next if length($g[0]) >2;
+        if( $g[2] eq "transcript" ) {
+            $keep = 0;
+            $keep = 1 if $g[8] =~ /transcript_biotype "protein_coding"/;
+        }
+        if( $g[2] eq "exon" and $keep ) {
+            print BASE $g[0]."\t".($g[3]-20)."\t".($g[4]+20)."\n";
+        }
+    }
+    ## All of mitochondria ##
+    print BASE "M\t1\t16569\n";
+    close GTF;
+    close BASE;    
+    
+}
+## concats bed files and adds 4th column describing why it was added
+sub add_to_bed {
+    my $bed = shift;
+    my $bed2add = shift;
+    my $forthcolumn = shift;
+    open(BED2ADD, $bed2add);
+    open(BED, '>>', $bed);
+    while (<BED2ADD>) {
+        chomp;
+        my @line = split('\t');
+        if ($line[3]) {
+            print BED $line[0]."\t".$line[1]."\t".$line[2]."\t".$line[3]."\n";    
+        }
+        else {
+            print BED $line[0]."\t".$line[1]."\t".$line[2]."\t".$forthcolumn."\n";
+        }
+        
+    }    
+    close BED;
+    close BED2ADD;
+}
+## merges bed-file targets and collapses 4th column
+sub sort_merge {
+    my $bed = shift;
+    system( "bedtools sort -i $bed > tmp.sort.bed" );
+    system( "bedtools merge -i tmp.sort.bed -c 4 -o collapse > $bed" );
+    unlink( "tmp.sort.bed");
+}
+## finds calculates which variants to add to new bed, and which to remove
+## depending on variant status. Take clinvar-hashes (old and new) returns
+## list of variants to create bed
+sub compare_clinvar {
+    my $new = shift;
+    my $old = shift;
+    my $final_bed = shift;
+    my %new = %$new;
+    my %old = %$old;
+    my $new_bed = "clinvar_new.bed";
+    my $old_bed = "clinvar_old.bed";
+    open (NEW,'>',$new_bed);
+    open (OLD,'>',$old_bed);
+    my @incommon = ();
+    foreach my $key (keys %new ) {
+        push(@incommon, $key) if exists $old{$key};
+        print NEW $new{$key}->{CHROM}."\t";
+        print NEW ($new{$key}->{POS} - 5)."\t";
+        print NEW ($new{$key}->{POS} + 5)."\t";
+        my $info = clinvar_info($new{$key},$key);
+        print NEW "$info\n";
+
+    }
+    my @new_added = ();
+    foreach my $key (keys %new ) {
+        push(@new_added, $key) unless exists $old{$key};
+    }
+    my @old_removed = ();
+    foreach my $key (keys %old ) {
+        unless (exists $new{$key}) {
+            push(@old_removed, $key);
+            print OLD $old{$key}->{CHROM}."\t";
+            print OLD ($old{$key}->{POS} - 5)."\t";
+            print OLD ($old{$key}->{POS} + 5)."\t";
+            my $info = clinvar_info($old{$key},$key);
+            print OLD "$info\n";
+        }
+
+    }
+    close NEW;
+    close OLD;
+
+    my @add2bed = push(@incommon,@new_added);
+    my $newtoadd = intersect($new_bed,$final_bed);
+    unlink($new_bed);
+    my $oldtoremove = intersect($old_bed,$final_bed);
+    unlink($old_bed);
+    print "clinvar in common between versions :".scalar(@incommon)."\n";
+    print "added new(unique targets)          :".scalar(@new_added)."(".scalar(@{$newtoadd}).")"."\n";
+    print "removed old(unique targets)        :".scalar(@old_removed)."(".scalar(@{$oldtoremove}).")"."\n";
+    return $newtoadd,$oldtoremove;
+}
+## finds unique targets, important to keep track of what variants gets added
+## and what variants get removed
+sub intersect {
+    my $clinvar = shift;
+    my $bed = shift;
+    my @notinbed = `bedtools intersect -a $clinvar -b $bed -v`;
+    return \@notinbed;
+}
+## concats INFO-field into 4th column for clinvarbed
+sub clinvar_info {
+    my $info = shift;
+    my $var = shift;
+    my %info = %$info;
+    my @forth;
+    push (@forth,$var);
+    push (@forth,$info->{REASON});
+    push (@forth,$info->{INFO}->{CLNACC});
+    push (@forth,$info->{INFO}->{CLNDN});
+    my $forth = join('~',@forth);
+    return $forth;
+}
+## creates a log for added and removed clinvar variants as well
+## as creates the bed that gets added to the final big bed-file
+sub clinvar_bed_andinfo {
+    my $clinvar = shift;
+    my $neworold = shift;
+    my $clinvarlog = shift;
+    open (LOG,'>>',$clinvarlog);
+    foreach my $target (@{ $clinvar }) {
+        chomp($target);
+        my @line = split('\t',$target);
+        my @clinvarreason = split("~",$line[3]);
+        my @pos = split('_',$clinvarreason[0]);
+        if ($neworold eq "old") {
+            my $innew = "MISSING";
+            if ($new_benign{$clinvarreason[0]}->{INFO}->{CLNSIG}) {
+                $innew = $new_benign{$clinvarreason[0]}->{INFO}->{CLNSIG};
+            }
+            print LOG "REMOVED:".$pos[0].":".$clinvarreason[2].":".$clinvarreason[1]."=>".$innew."\n";
+        }
+        elsif ($neworold eq "new") {
+            print LOG "ADDED:".$pos[0].":".$clinvarreason[2].":".$clinvarreason[1]."\n";
+        }
+        else {
+            print LOG $line[0]."\t".$line[1]."\t".$line[2]."\t"."CLINVAR-$clinvarreason[1]\n";
+        }
+        
+    }
+    close LOG;
+}

--- a/bin/reference_tools/vcf2.pm
+++ b/bin/reference_tools/vcf2.pm
@@ -1,0 +1,292 @@
+package CMD::vcf2;
+use strict;
+use Data::Dumper;
+use Exporter qw(import);
+our @EXPORT_OK = qw( new next_line parse_vcf parse_metainfo parse_variant parse_genotype parse_info ); 
+
+
+sub new {
+    my( $class, @args ) = @_;
+    my $self = {@args};
+    bless $self, $class;
+    return $self->_open();
+}
+
+sub _open {
+    my( $self ) = @_;
+    my $fn = $$self{file};
+
+    if( is_gzipped($fn) ) {
+        open( $$self{fh}, "zcat $fn |" ) or die "Could not open file $fn";
+    }
+    else {
+        open( $$self{fh}, $fn ) or die "Could not open file $fn";;
+    }
+
+    my @head ;
+    my $full_header_str;
+
+    while( readline($$self{fh}) ) {
+	chomp;
+
+	# Skip empty lines
+	next if /^\s*$/;
+
+	$full_header_str .= $_."\n" if /^#/;
+	
+	# Header row with meta data.
+	if( /^##/ ) {
+	    my( $type, $meta, $val ) = parse_metainfo( $_ );
+	    if( $type ne "NONE" ) {
+		$$self{meta}->{$type}->{$meta->{ID}} = $meta;
+	    }
+	    else {
+		$$self{meta}->{$meta} = $val;
+	    }
+	}
+
+	# Header with column description.
+	elsif( /^#/ ) {
+	    $_ =~ s/^#//;
+	    @head = split /\t/;
+	    last;
+	}
+    }
+
+    @{$$self{head}} = @head;
+    $$self{samples} = splice @head, 9;
+
+    $$self{header_str} = $full_header_str;
+
+    return $self;
+}
+
+sub next_var {
+    my ($self) = @_;
+    
+    my $line = readline($$self{fh});
+    if ($line) {
+	chomp $line;
+
+	my $variant = parse_variant( $line, $$self{head}, $$self{meta} );
+
+	if( $variant->{CHROM} ) {
+	    return $variant if defined $variant;
+	}
+    }
+    return 0;
+}
+
+# Parse VCF file and return
+sub parse_vcf {
+    
+    my $fn = shift;
+    my %vcf_meta;
+    my @vcf_data;
+    my @head ;
+    my $full_header_str;
+
+    my $vcf_fh;
+    if( is_gzipped($fn) ) {
+#    if( $fn =~ /\.gz/ ) {
+	open( $vcf_fh, "zcat $fn |" );
+    }
+    else {
+	open( $vcf_fh, $fn );
+    }
+	
+    while( <$vcf_fh> ) {
+	chomp;
+
+	# Skip empty lines
+	next if /^\s*$/;
+
+	$full_header_str .= $_."\n" if /^#/;
+	
+	# Header row with meta data.
+	if( /^##/ ) {
+	    my( $type, $meta ) = parse_metainfo( $_ );
+	    $vcf_meta{$type}->{$meta->{ID}} = $meta if defined $type;
+	}
+
+	# Header with column description.
+	elsif( /^#/ ) {
+	    #print STDERR $_;
+	    $_ =~ s/^#//;
+	    @head = split /\t/;
+	}
+
+	# Actual variant data
+	else {
+	    die "Malformed VCF: No column description header." unless @head;
+	    my $variant = parse_variant( $_, \@head, \%vcf_meta );
+	    if( $variant->{CHROM} ) {
+		push @vcf_data, $variant if defined $variant;
+	    }
+	}
+    }
+
+    my @samples = splice @head, 9;
+    $vcf_meta{header_str} = $full_header_str;
+    
+    return \%vcf_meta, \@vcf_data, \@samples;
+}
+
+
+
+
+# Parse VCF meta info line (only FORMAT and INFO)
+sub parse_metainfo {
+    my $comment = shift;
+    
+    $comment =~ s/^##//;
+    my( $type, $data ) = ( $comment =~ /^(.*?)=(.*)$/ );
+
+
+    if( $type eq "FORMAT" or $type eq "INFO" or $type eq "SAMPLE" or $type eq "FILTER" ) {
+	$data = remove_surrounding( $data, '<', '>' );
+	my( $pairs, $order ) = keyval( $data, '=', ',' );
+	return $type, $pairs, 0;
+    } 
+    elsif( $type and $data ) {
+	return "NONE", $type, $data;
+    }
+	
+
+    return undef, undef, undef;
+}
+
+
+# Parse VCF variant line
+sub parse_variant {
+    my( $var_str, $head, $meta ) = @_;
+    my @var_data = split /\t/, $var_str;
+    my %var;
+
+    $var{ vcf_str } = $var_str;
+    
+    # First seven fields
+    for ( 0..6 ) {
+	$var{ $head->[$_] } = $var_data[$_];
+    }
+
+    # Eigth field, INFO
+    ( $var{ INFO }, $var{INFO_order} ) = parse_info( $var_data[7] );
+
+    # Parse VEP annotation field, if any
+    if( $var{ INFO }->{ CSQ } ) {
+        $var{ _CSQstr } = $var{INFO}->{CSQ};
+	    $var{ INFO }->{ CSQ } = parse_VEP_CSQ( $var{INFO}->{CSQ}, $meta->{INFO}->{CSQ} );
+    }
+
+    #my @FORMAT = split /:/, $var_data[8];
+    #$var{ FORMAT} = \@FORMAT;
+    
+    # Genotypes for each sample
+    for ( 9 .. (@var_data-1) ) {
+	    push @{$var{ GT }}, parse_genotype( $var_data[8], $var_data[$_], $head->[$_] );
+    }
+
+    return \%var;
+}
+
+
+# Parse genotype field of VCF
+sub parse_genotype {
+    my( $format, $data, $sample_id ) = @_;
+
+    my @format = split ':', $format;
+    my @data   = split ':', $data;
+
+    my %gt;
+    @gt{@format} = @data;
+    $gt{_sample_id} = $sample_id;
+
+    return \%gt;
+}
+
+
+# Parse info column of VCF file
+sub parse_info {
+    my $str = shift;
+    my( $info, $order ) = keyval( $str, "=", ";" );
+
+    return $info, $order;
+}
+
+
+sub parse_VEP_CSQ {
+    my( $CSQ_var, $CSQ_meta ) = @_;
+
+    $CSQ_meta->{Description} =~ /Consequence annotations from Ensembl VEP\. Format: (.*?)$/;
+
+    my @field_names = split /\|/, $1;
+    
+    my @transcripts = split /,/, $CSQ_var;
+
+    my @data_transcripts;
+    foreach my $transcript_CSQ ( @transcripts ) {
+	my @values = split /\|/, $transcript_CSQ;
+
+	my %data;
+	for( 0 .. $#field_names ) {
+	    if( $field_names[$_] eq "Consequence" ) {
+		my @conseq_array = split '&', $values[$_];
+		$data{ $field_names[$_] } = \@conseq_array;
+	    }
+	    else {
+		$data{ $field_names[$_] } = ( $values[$_] or "" );
+	    }
+	}
+
+	push( @data_transcripts, \%data )
+    }
+    return \@data_transcripts;
+}
+
+# Removes character(s) defined in arg2 if first in string, and arg3 if last in string.
+sub remove_surrounding {
+    my( $str, $before, $after ) = @_;
+    $str =~ s/^$before//;
+    $str =~ s/$after$//;
+    return $str;
+}
+
+
+# Parse string with key value pairs. Return hash. 
+#  * Keys and values separated by 2nd argument. 
+#  * Pairs separated by 3rd argument
+#  * Handles commas in values if surrounded by double quotes
+sub keyval {
+    my( $str, $keyval_sep, $pair_sep ) = @_;
+
+    my @pair_str = split /$pair_sep/, $str;
+    my %pairs;
+    my @order;
+    foreach( @pair_str ) {
+
+	# If key-value separator exists, save the value for the key
+	if( /$keyval_sep/ ) {
+	    my( $key, $val ) = split /$keyval_sep/;
+	    $pairs{$key} = $val;
+	    push @order, $key;
+	}
+
+	# Otherwise treat the whole string as a flag and set it to one (true).
+	else {
+	    $pairs{$_} = 1;
+	}
+    }
+    return \%pairs, \@order;
+}
+
+sub is_gzipped {
+    my $fn = shift;
+
+    my $file_str = `file -L $fn`;
+    return 1 if $file_str =~ /gzip compressed/;
+    return 0;
+}
+
+
+1;

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -98,7 +98,7 @@ profiles {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'wgs'
     params.crondir = "${params.outdir}/cron/"
-    params.intersect_bed = "${params.refpath}/bed/wgsexome/hg38_ens98_allcodingexons20bppadding_allclinvar5bppadding_agilent.bed"
+    params.intersect_bed = "${params.refpath}/bed/wgsexome/active.bed"
     params.align = true
     params.varcall = true
     params.annotate = true


### PR DESCRIPTION
tool to update bed-file

fetches ensembl build gtf and extracts relevant regions (exonic regions of coding genes)
merges with old agilent exome
adds non-overlapping clinvar-variants to bed file and logs what variants were added since last version of clinvar and which were removed

To test:
./update_bed.pl --old /data/bnf/ref/annotations_dbs/clinvar38_20200106.vcf.gz --new /fs1/resources/ref/hg38/annotation_dbs/clinvar38_latest.vcf.gz --clinvardate 20221129 --build 108