### PR TITLE
avoiding annotation to empty sv-vcfs

### DIFF
--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -322,7 +322,7 @@ modycf {
     params.bed_melt = "${params.refpath}/bed/MELT/Hg38.genes.bed"
     params.mei_list = "${params.refpath}/annotation_dbs/MELT/mei_list.txt"
     params.meltheader = "/fs1/resources/ref/hg38/annotation_dbs/MELT/melt_vcf_header"
-    params.svdb = "${params.refpath}/annotation_dbs/onco-solid/loqusdb/loqusdb_oncosv_export_20220318.vcf"
+    params.svdb = "${params.refpath}/annotation_dbs/modycf/loqusdb/loqusdb_modycfsv_export_20230220.vcf"
     params.svrank_model_s = "/fs1/resources/scout/rank_models_38/svrank_single_v1.0_panel.ini"
     params.rank_model = "/fs1/resources/scout/rank_models_38/rank_model_cmd_v4.ini"
     params.rank_model_s = "/fs1/resources/scout/rank_models_38/rank_model_cmd_v4_single_withoutmodels_onco.ini"


### PR DESCRIPTION
modycf profile created with paths exclusive for modycf analysis in configs/nextflow.hopper.config. Also added some minor changes in main.nf accomodating the modycf-profile, the most important one being the conditions introduced in annotsv and vep_sv to avoid annotation of empty vcfs