### PR TITLE
Fix melt slice variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.5.2
+- MELT is no longer filtered on location based upon regex names INTRONIC/null/PROMOTER, instead added a intersect towards bedfile. This will show splice site variants
+
 ### 3.5.1
 
 * Add REVEL (Rare Exome Variant Ensemble Learner) Scores to VEP annotations (VEP REVEL_rankscore and REVEL_score)

--- a/bin/merge_melt.pl
+++ b/bin/merge_melt.pl
@@ -67,7 +67,7 @@ foreach my $file (@files) {
         my $start = $a -> {POS};
 
         ## Filter variants in introns and invalid positions
-        if ($a->{INFO}->{INTERNAL} =~ /INTRONIC|null|PROMOTER/) { next; }
+        #if ($a->{INFO}->{INTERNAL} =~ /INTRONIC|null|PROMOTER/) { next; }
         ## Filter variants due to low quality for sample
         if ($a->{FILTER} =~ /ac0/) { next; }
 


### PR DESCRIPTION
Disabled filtering of INTRONIC/null/PROMOTER variants from melt-vcf. Instead do intersection with bedtools against designbed. Will only remove unwanted regions and keep relevant.

Before we would miss out on rare splice-site variants.

I also added publishdirs for the unfiltered merged-melt-vcf and for the intersected