### PR TITLE
Increase melt sens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.5.3
+- Hotfix, increase melt sensivity by increasing amount of reads melt are alowed to use in RAM. 
+
 ### 3.5.2
 - MELT is no longer filtered on location based upon regex names INTRONIC/null/PROMOTER, instead added a intersect towards bedfile. This will show splice site variants
 

--- a/main.nf
+++ b/main.nf
@@ -697,7 +697,7 @@ process melt {
 		-r 150 \\
 		-h $genome_file \\
 		-n /opt/MELTv2.2.2/add_bed_files/Hg38/Hg38.genes.bed \\
-		-z 50000 \\
+		-z 500000 \\
 		-d 50 -t /opt/mei_list \\
 		-w . \\
 		-c $MEAN_DEPTH \\


### PR DESCRIPTION
Increased amount of reads melt can use in RAM. Process already under-utilize RAM by far. Average mem peak below 10GB increasing should just yield more consistent calling and remove a lot of randomness.