### PR TITLE
hg38 masked genome build and GATK references

### DIFF
--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -94,6 +94,11 @@ process {
 }
 
 profiles {
+  hg38_masked {
+    params.genome_file="${params.refpath}/fasta/masked/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr_masked.fna"
+    params.GENOMEDICT="${params.refpath}/fasta/masked/GCA_000001405.15_GRCh38_no_alt_analysis_set_nochr_masked.dict"
+  }
+  
   wgs {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'wgs'
@@ -126,9 +131,9 @@ profiles {
     params.assay = "wgs"
     params.noupload = false
     params.vcfanno = "${params.refpath}/annotation_dbs/wgs/vcfanno/vcf_anno"
-    params.gatk_intervals = "${params.refpath}/gatk_cnv/cnvref/grch38.preprocessed.blacklisted.gcfiltered.interval_list"
-    params.ploidymodel = "${params.refpath}/gatk_cnv/cnvref/ploidy-model"
-    params.gatkreffolders = "${params.refpath}/gatk_cnv/cnvref/gatk_ref"
+    params.gatk_intervals = "${params.refpath}/gatk_cnv/cnvref/masked_hg38/masked_hg38.preprocessed.blacklisted.gcfiltered.noalt.interval_list"
+    params.ploidymodel = "${params.refpath}/gatk_cnv/cnvref/masked_hg38/ploidy-model"
+    params.gatkreffolders = "${params.refpath}/gatk_cnv/cnvref/masked_hg38/gatk_ref"
     params.gens_accessdir = "/access/wgs/plot_data"
     params.accessdir = params.loaddir + "/wgs/"
   }


### PR DESCRIPTION
Added a profile for masked hg38 reference. This update includes WGS references build with this new genome build for GATK and has passed validation. Future updates to GENS PoN needs to be done once this has been in production for a month or so

Tests needs to be passed:
Oncov1-0 sample [V]
Oncov2-0 sample [V]
WGS sample trio [V]
WGS sample single [V]

WGS is tested fully into Scout via validation and onco profiles does not need to be tested for scout import. 