### PR TITLE
Fixing the final log dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 3.5.5
+
+* Update the cron log directory to use the `params.crondir` folder as base
+
 ### 3.5.4
 
 * Add version outputs from all processes that use external software.

--- a/main.nf
+++ b/main.nf
@@ -52,7 +52,7 @@ workflow.onComplete {
 		.stripIndent()
 
 	base = csv.getBaseName()
-	File logFile = new File("${params.resultsdir}/cron/logs/${base}.complete")
+	File logFile = new File("${params.crondir}/logs/${base}.complete")
 	if (!logFile.getParentFile().exists()) {
 		logFile.getParentFile().mkdirs()
 	}


### PR DESCRIPTION
Minimal patch on the now merged stub-PR.

I updated the final CRON log dir to instead of being hard coded using the "results" dir as base.

This works as long as you specify the results dir within the config. But if you would like to use the `--outdir` argument in the run nextflow command, then it does no longer work.

Here is the logic:

* `resultsdir` - specified within the config only (`/fs1/results` for production)
* `outdir` - this is by default `resultsdir` + `devsuffix`, but can be specified in the `runnextflow.pl` runscript as an argument
* `crondir` - is `outdir` + "cron"

This PR updates the final log file to be written to a path specified by `crondir` + "logs" rather than `resultsdir` + "/cron/log"

I have successfully done stubruns and a test run.

It would be valuable to get an extra pair of eyes on it (and on the default config-files, to make sure the logic is OK). Not sure whether it is worth doing further testing.