### PR TITLE
Add `documentation` to type of change section in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,8 +31,13 @@ fixes # (issue)
 
 # Checklist:
 <!--
-    The checklist below applies to all types of changes. 
-    
+    The checklist below applies to all types of changes, 
+    except documentation updates. 
+
+    In the case of changes that only affect documentation external to 
+    code source files, remove the checkboxes related to code review
+    and testing for no new warnings.
+        
     Do not hesitate to add your own items to the checklist if applicable.
 -->
 - [ ] My code follows the [style guidelines for NF pipelines at CMD](http://mtlucmds1.lund.skane.se/wiki/doku.php?id=nextflow&s[]=nextflow#code_style_at_cmd)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,14 @@
 <!--
 # clinical-genomics-lund/nextflow_wgs pull request
 
-Thanks for contributing to the CMD nextflow_wgs pipeline. 
+Thanks for contributing to the CMD nextflow_wgs pipeline.
 -->
 # Description
-
 <!--
 Add a description of changes below and a description of the expected outcome.
 -->
 
 What is changed? What is the result of the changes?
-
 <!--
     Are there any issue or issues that are linked to this PR? 
     Use Github's syntax for closing keywords: `closes #1` or `fixes #1`
@@ -19,7 +17,6 @@ What is changed? What is the result of the changes?
 fixes # (issue)
 
 ## Type of change
-
 <!--
     Major change counts as a change that breaks backward compatibility
     Minor change is a substantial change that requires testing before deployment
@@ -27,19 +24,17 @@ fixes # (issue)
     
     Choose one and delete the remaining fields.
 -->
-
 - [ ] Major change 
 - [ ] Minor change
 - [ ] Patch
+- [ ] Documentation
 
 # Checklist:
-
 <!--
     The checklist below applies to all types of changes. 
     
     Do not hesitate to add your own items to the checklist if applicable.
 -->
-
 - [ ] My code follows the [style guidelines for NF pipelines at CMD](http://mtlucmds1.lund.skane.se/wiki/doku.php?id=nextflow&s[]=nextflow#code_style_at_cmd)
 - [ ] I have performed a self-review of my code
 - [ ] I have commented my code, particularly in hard-to-understand areas
@@ -49,12 +44,10 @@ fixes # (issue)
       with the correct version number
 
 <!--
-    Select a checklist below  based on selection under # Type of change
+    Select a checklist below based on selection under # Type of change
     and delete the sections that do not apply to this PR:
 -->
-
 ## Major change
-
 - [ ] Stub run completes without errors or new warnings
 - [ ] `onco` run finishes without any new warnings/errors and the results can 
        be loaded into scout
@@ -66,7 +59,6 @@ fixes # (issue)
 - [ ] I have made corresponding changes to the documentation
 
 ## Minor change
-
 - [ ] Stub run completes without errors or new warnings
 - [ ] `onco` run finishes without any new warnings/errors and the results can 
        be loaded into scout
@@ -78,7 +70,6 @@ fixes # (issue)
 - [ ] I have made corresponding changes to the documentation
 
 ## Patch
-
 - [ ] Stub run completes without errors or new warnings
 <!--
     Remove the comment markers wrapping the checkbox below if you believe that 
@@ -90,37 +81,39 @@ fixes # (issue)
 - [ ] At least one other person has reviewed and approved my code
 -->
 
+<!--
+    Remove the comment markers wrapping the sectopm below if you believe that 
+    the updated documentation needs to undergo review.
+-->
+<!--
+## Documentation
+- [ ] At least one other person has reviewed my changes
+-->
+
 ## [Optional] Are there any post-deployment tasks we need to perform?
- 
 <!--
     Some examples of post-deployment tasks are pipeline validation for a major 
     change  update or an update to CDM to accomodate new QC data.
 -->
-
  - [ ] Task/link to issue 1
  - [ ] Task/link to issue 2
  - [ ] ...
  
 # Instructions for the reviewers
-
 <!--
     Use this section to guide the reviewer in how to 
     test your proposed 
 -->
-
 ## How to test the changes
-
 <!--
     Provide clear and concise steps for reviewers to test your changes. 
     Include any specific commands, inputs, or conditions they should be aware 
     of.
 -->
-
 1. Step 1
 2. Step 2
 
 ## Expected outcome
-
 <!--
     Describe what the expected outcome should be after your changes are 
     implemented. This helps reviewers understand the goal and verify if 
@@ -128,30 +121,25 @@ fixes # (issue)
 -->
 
 ## [Optional] Additional information
-
 <!--
     If there's any extra information, context,  or considerations that would be
     helpful for reviewers, feel free to include them here.
 -->
 
 # Review
-
 <!--
     Use this section to document who has performed the reviews and run the 
     tests. 
 -->
 
 ## Review performed by:
-
 - Reviewer 1: Name1, (\@Github\_handle1)  
 - Reviewer 2: Name1,  (\@Github\_handle2)
 - ...
     
 ## Testing performed by:
-
 - Name, (\@Github\_handle)
 - ...
 
 # Post-merge
-
 - [ ] The `master` branch has been tagged with the new version number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # CHANGELOG
+### 3.5.10
+* Add `documentation` to change type category in PR template.
 
 ### 3.5.9
 


### PR DESCRIPTION
<!--
# clinical-genomics-lund/nextflow_wgs pull request

Thanks for contributing to the CMD nextflow_wgs pipeline. 
-->
# Description

<!--
Add a description of changes below and a description of the expected outcome.
-->

Add new type of change to this PR template: `documentation`.

Updates to documentation external to code source are exempted from code review/stub runs.

Might still be good idea to do a test run of the pipeline when commenting code, say because of some whitespace error straight from hell.

<!--
    Are there any issue or issues that are linked to this PR? 
    Use Github's syntax for closing keywords: `closes #1` or `fixes #1`
-->

closes #108 

## Type of change

<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
    
    Choose one and delete the remaining fields.
-->

- [x] Documentation (meta!)

# Checklist:

<!--
    The checklist below applies to all types of changes. 
    
    Do not hesitate to add your own items to the checklist if applicable.
-->

- [x] I have updated the CHANGELOG
- [x] The latest commit in the master branch is tagged
      with the correct version number

## Other

- [ ] At least one other person has reviewed and approved this change
 

# Review

<!--
    Use this section to document who has performed the reviews and run the 
    tests. 
-->

## Review performed by:

- Reviewer 1: Jakob, @Jakob37 
- ...
    
## Testing performed by:

# Post-merge

- [ ] The `master` branch has been tagged with the new version number.
