### PR TITLE
Update intersect file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.6.3
+* Update intersect file to latest used version of ClinVar (20231230)
+
 ### 3.6.2
 * Added changelog reminder to github workflows
 

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -98,7 +98,7 @@ profiles {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'wgs'
     params.crondir = "${params.outdir}/cron/"
-    params.intersect_bed = "${params.refpath}/bed/wgsexome/active.bed"
+    params.intersect_bed = "${params.refpath}/bed/wgsexome/exons_108padded20bp_clinvar-20231230padded5bp.bed"
     params.align = true
     params.varcall = true
     params.annotate = true


### PR DESCRIPTION
# Description

The updated intersect file is produced as described below. I also placed a `CHANGELOG` file in the same folder for future travelers.

We decided to update the config to point directly to the new file rather than the "active" as a way to document it.

We might automate the generation of this file in the same way the clinvar file (on which it is based) is updated.

We talked about bunching together this update with the updates for Sentieon and VEP.

```
perl update_bed.pl --old clinvar38_20221129.vcf --new clinvar38_20231230.vcf --build 108 --clinvardate 20231230
```

Diff result:

```
clinvar in common between versions :249890
added new(unique targets)          :49276(1159)
removed old(unique targets)        :3471(21)
```

Close #123 

## Type of change
* Minor change

# Checklist:
- [x] I have updated the CHANGELOG
- [x] The latest commit in the master branch is tagged
      with the correct version number

## Minor change
- [x] Stub run completes without errors or new warnings
- [x] `wgs` single run finishes without any new warnings/errors and the results 
      can be loaded into scout
- [x] `wgs` trio run finishes without any new warnings/errors and the results 
       can be loaded into scout
- [x] At least one other person has reviewed and approved my code

# Review

## Review performed by:
- Reviewer 1: Alexander Koc, (@alkc)
- Reviewer 2: Name1,  (\@Github\_handle2)
- ...
    
## Testing performed by:
- Alexander Koc, (@alkc)

# Post-merge
- [x] The `master` branch has been tagged with the new version number.
