### PR TITLE
Rank model updates for VEP 111

### DIFF
--- a/rank_models/rank_model_v5.2.1.ini
+++ b/rank_models/rank_model_v5.2.1.ini
@@ -385,6 +385,21 @@
     priority = 4
     string = 'splice_region_variant'
 
+  [[splice_donor_5th_base_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_donor_5th_base_variant'
+
+  [[splice_donor_region_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_donor_region_variant'
+
+  [[splice_polypyrimidine_tract_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_polypyrimidine_tract_variant'
+
   [[missense_variant]]
     score = 5
     priority = 4
@@ -435,6 +450,11 @@
     priority = 2
     string = 'upstream_gene_variant'
 
+  [[coding_transcript_variant]]
+    score = 1
+    priority = 2
+    string = 'coding_transcript_variant'
+
   [[regulatory_region_amplification]]
     score = 1
     priority = 2
@@ -469,6 +489,11 @@
     score = 1
     priority = 2
     string = 'TF_binding_site_variant'
+
+ [[start_retained_variant]]
+    score = 1
+    priority = 2
+    string = 'start_retained_variant'
 
   [[stop_retained_variant]]
     score = 1
@@ -509,6 +534,11 @@
     score = 0
     priority = 0
     string = 'intergenic_variant'
+
+  [[sequence_variant]]
+    score = 1
+    priority = 0
+    string = 'sequence_variant'
 
   [[not_reported]]
     score = 0

--- a/rank_models/svrank_model_v5.2__FIXARTEFACTCUTOFF.ini
+++ b/rank_models/svrank_model_v5.2__FIXARTEFACTCUTOFF.ini
@@ -158,6 +158,22 @@
     score = 5
     priority = 4
     string = 'splice_region_variant'
+
+  [[splice_donor_5th_base_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_donor_5th_base_variant'
+
+  [[splice_donor_region_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_donor_region_variant'
+
+  [[splice_polypyrimidine_tract_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_polypyrimidine_tract_variant'
+
   
   [[missense_variant]]
     score = 5
@@ -203,7 +219,13 @@
     score = 1
     priority = 2
     string = 'regulatory_region_variant'
-  
+
+  [[coding_transcript_variant]]
+    score = 1
+    priority = 2
+    string = 'coding_transcript_variant'
+
+
   [[upstream_gene_variant]]
     score = 1
     priority = 2
@@ -248,7 +270,12 @@
     score = 1
     priority = 2
     string = 'stop_retained_variant'
-  
+
+ [[start_retained_variant]]
+    score = 1
+    priority = 2
+    string = 'start_retained_variant'
+
   [[feature_elongation]]
     score = 1
     priority = 2
@@ -283,7 +310,13 @@
     score = 0
     priority = 0
     string = 'intergenic_variant'
-  
+
+  [[sequence_variant]]
+    score = 1
+    priority = 0
+    string = 'sequence_variant'
+
+
   [[not_reported]]
     score = 0
     


### PR DESCRIPTION
This PR is just material for discussion at today's WGS meeting

Additions to consequence severity ranking: 

```
my %rank = (                                    
    'transcript_ablation' => 1,                 
    'initiator_codon_variant' => 2,             
    'frameshift_variant' => 3,                  
    'stop_gained' => 4,                         
    'start_lost' => 5,                          
    'stop_lost' => 6,                           
    'splice_acceptor_variant' => 7,             
    'splice_donor_variant' => 8,                
    'inframe_deletion' => 9,                    
    'transcript_amplification' => 10,           
    'splice_donor_5th_base_variant' => 11,  <-----------------
    'splice_region_variant' => 12,              
    'splice_donor_region_variant' => 13, <--------------------
    'splice_polypyrimidine_tract_variant' => 14,  <-----------
    'missense_variant' => 15,                   
    'protein_altering_variant' => 16,           
    'inframe_insertion' => 17,                  
    'incomplete_terminal_codon_variant' => 18,  
    'non_coding_transcript_exon_variant' => 19, 
    'synonymous_variant' => 20,                 
    'mature_mirna_variant' => 21,               
    'non_coding_transcript_variant' => 22,      
    'regulatory_region_variant' => 23,          
    'upstream_gene_variant' => 24,              
    'regulatory_region_amplification' => 25,    
    'tfbs_amplification' => 26,                 
    '5_prime_utr_variant' => 27,                
    'intron_variant' => 28,                     
    '3_prime_utr_variant' => 29,                
    'feature_truncation' => 30,                 
    'coding_transcript_variant' => 31,  <---------------------
    'tf_binding_site_variant' => 32,            
    'start_retained_variant' => 33,             
    'stop_retained_variant' => 34,              
    'feature_elongation' => 35,                 
    'regulatory_region_ablation' => 36,         
    'tfbs_ablation' => 37,                      
    'coding_sequence_variant' => 38,            
    'downstream_gene_variant' => 39,            
    'nmd_transcript_variant' => 40,             
    'intergenic_variant' => 41,                 
    'sequence_variant' => 42   <-----------------------------
    );                                          
```