### PR TITLE
added csv-file path to onComplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.7.8?
+* added csv-file to onComplete function to accomodate CCCP
+
 ### 3.7.7
 #### create_yml.pl
 * small name change for myeloid constitutional to match clarity

--- a/main.nf
+++ b/main.nf
@@ -41,6 +41,7 @@ workflow.onComplete {
 		Success     : ${workflow.success}
 		scriptFile  : ${workflow.scriptFile}
 		workDir     : ${workflow.workDir}
+		csv         : ${params.csv}
 		exit status : ${workflow.exitStatus}
 		errorMessage: ${workflow.errorMessage}
 		errorReport :


### PR DESCRIPTION
# Description
Added another value to the onComplete function for CCCP to use


## Type of change

- [ ] Major change 
- [ ] Minor change
- [ ] Patch
- [ ] Documentation

# Checklist:
- [ ] My code follows the [style guidelines for NF pipelines at CMD](http://mtlucmds1.lund.skane.se/wiki/doku.php?id=nextflow&s[]=nextflow#code_style_at_cmd)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings (Keep an eye on `.nextflow.log` !)
- [ ] I have updated the CHANGELOG
- [ ] The latest commit in the master branch is tagged
      with the correct version number

## Patch
- [ ] Stub run completes without errors or new warnings



## Documentation
- [ ] At least one other person has reviewed my changes

## Expected outcome
The log-file should include the path to the csv-file


# Post-merge
- [ ] The `master` branch has been tagged with the new version number.
