### PR TITLE
Added GQ to format field of all individuals via filter_mutect2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.7.10
+* Tag Mitochondrial variants with GQ, loqusdb enabling
+
 ### 3.7.9
 * Add CRON file to load Chanjo2
 

--- a/bin/filter_mutect2_mito.pl
+++ b/bin/filter_mutect2_mito.pl
@@ -43,52 +43,56 @@ while ( my $a = $vcf->next_var() ) {
 
 sub genotype_quality {
     # Add placeholder 99 GQ to each individual
+    # Also update genotype to 1/1 if AF>99%
     my $gt = shift;
     my $c = 0;
     foreach my $ind ( @{ $gt }) {
        $gt->[$c]->{GQ} = 99;
+       if ($ind->{AF} >= 0.99) {
+            $gt->[$c]->{GT} = '1/1';
+       }
        $c++;
     }
     return $gt;
 }
 
 sub vcfstr {
-	my( $v, $sample_order ) = @_;
-	
-	my @all_info;
-	my $tot_str = $v->{CHROM}."\t".$v->{POS}."\t".$v->{ID}."\t".$v->{REF}."\t".$v->{ALT}."\t".$v->{QUAL}."\t".$v->{FILTER}."\t";
+    my( $v, $sample_order ) = @_;
+    
+    my @all_info;
+    my $tot_str = $v->{CHROM}."\t".$v->{POS}."\t".$v->{ID}."\t".$v->{REF}."\t".$v->{ALT}."\t".$v->{QUAL}."\t".$v->{FILTER}."\t";
 
-	# Generate and print INFO field
-	for my $info_key (@{$v->{INFO_order}}) {
-		if($info_key eq "CSQ") {
-			push @all_info, $info_key."=".$v->{_CSQstr};
-		}
-		else {
-			push @all_info, $info_key."=".$v->{INFO}->{$info_key};
-		}
-	}
-	$tot_str = $tot_str.join(";", @all_info)."\t";
+    # Generate and print INFO field
+    for my $info_key (@{$v->{INFO_order}}) {
+        if($info_key eq "CSQ") {
+            push @all_info, $info_key."=".$v->{_CSQstr};
+        }
+        else {
+            push @all_info, $info_key."=".$v->{INFO}->{$info_key};
+        }
+    }
+    $tot_str = $tot_str.join(";", @all_info)."\t";
 
-	# Print FORMAT field
-	$tot_str = $tot_str.join(":", @{$v->{FORMAT}})."\t";
+    # Print FORMAT field
+    $tot_str = $tot_str.join(":", @{$v->{FORMAT}})."\t";
 
 
-	my %order;
-	my $i=0;
-	if( @$sample_order > 0 ) {
-		$order{$_} = $i++ foreach @{$sample_order};
-	}
-	else {
-		$order{$_->{_sample_id}} = $i++ foreach @{$v->{GT}};
-	}
-	# Print GT fields for all samples
-	for my $gt ( sort {$order{$a->{_sample_id}} <=> $order{$b->{_sample_id}}} @{$v->{GT}}) {
-		my @all_gt;
-		for my $key ( @{$v->{FORMAT}} ) {
-			push @all_gt, ( defined $gt->{$key} ? $gt->{$key} : "");
-		}
-		$tot_str = $tot_str.join(":", @all_gt)."\t";
-	}
-	$tot_str = $tot_str."\n";
-	return $tot_str;
+    my %order;
+    my $i=0;
+    if( @$sample_order > 0 ) {
+        $order{$_} = $i++ foreach @{$sample_order};
+    }
+    else {
+        $order{$_->{_sample_id}} = $i++ foreach @{$v->{GT}};
+    }
+    # Print GT fields for all samples
+    for my $gt ( sort {$order{$a->{_sample_id}} <=> $order{$b->{_sample_id}}} @{$v->{GT}}) {
+        my @all_gt;
+        for my $key ( @{$v->{FORMAT}} ) {
+            push @all_gt, ( defined $gt->{$key} ? $gt->{$key} : "");
+        }
+        $tot_str = $tot_str.join(":", @all_gt)."\t";
+    }
+    $tot_str = $tot_str."\n";
+    return $tot_str;
 }

--- a/bin/filter_mutect2_mito.pl
+++ b/bin/filter_mutect2_mito.pl
@@ -7,15 +7,17 @@ use vcf2;
 use strict;
 use Data::Dumper;
 
+# Variants are only interesting if they exist in proband. A 0/0 in proband is non-informative
+# Also require atleast 50 basepairs depth for sight.
+# Tag variants with a placeholder genotype quality to make downstream loqusdb accept variant
+
 
 my $line = 1;
 my $index;
 my $vcf = CMD::vcf2->new('file'=>$ARGV[0] );
 my $proband = $ARGV[1];
 print $vcf->{header_str};
-while ( my $a = $vcf->next_var() ) {
-
-    
+while ( my $a = $vcf->next_var() ) {    
     if ($line == 1) {
         my $count = 0;
         foreach my $ind (@{ $a->{GT} }) {
@@ -25,13 +27,68 @@ while ( my $a = $vcf->next_var() ) {
             $count++;
         }
     }
-
     ## variant exist in proband
     if ($a->{GT}->[$index]->{GT} =~ /1/) {
         ## variant has at least 50 depth    
         if ($a->{GT}->[$index]->{DP} > 50) {
-            print $a->{vcf_str}."\n";
+            my $gt = genotype_quality($a->{GT});
+            $a->{GT} = $gt;
+            push (@{$a->{FORMAT}},"GQ");
+            my $vcfstr = vcfstr($a,[]);
+            print $vcfstr;
         }
     }
     $line++;
+}
+
+sub genotype_quality {
+    # Add placeholder 99 GQ to each individual
+    my $gt = shift;
+    my $c = 0;
+    foreach my $ind ( @{ $gt }) {
+       $gt->[$c]->{GQ} = 99;
+       $c++;
+    }
+    return $gt;
+}
+
+sub vcfstr {
+	my( $v, $sample_order ) = @_;
+	
+	my @all_info;
+	my $tot_str = $v->{CHROM}."\t".$v->{POS}."\t".$v->{ID}."\t".$v->{REF}."\t".$v->{ALT}."\t".$v->{QUAL}."\t".$v->{FILTER}."\t";
+
+	# Generate and print INFO field
+	for my $info_key (@{$v->{INFO_order}}) {
+		if($info_key eq "CSQ") {
+			push @all_info, $info_key."=".$v->{_CSQstr};
+		}
+		else {
+			push @all_info, $info_key."=".$v->{INFO}->{$info_key};
+		}
+	}
+	$tot_str = $tot_str.join(";", @all_info)."\t";
+
+	# Print FORMAT field
+	$tot_str = $tot_str.join(":", @{$v->{FORMAT}})."\t";
+
+
+	my %order;
+	my $i=0;
+	if( @$sample_order > 0 ) {
+		$order{$_} = $i++ foreach @{$sample_order};
+	}
+	else {
+		$order{$_->{_sample_id}} = $i++ foreach @{$v->{GT}};
+	}
+	# Print GT fields for all samples
+	for my $gt ( sort {$order{$a->{_sample_id}} <=> $order{$b->{_sample_id}}} @{$v->{GT}}) {
+		my @all_gt;
+		for my $key ( @{$v->{FORMAT}} ) {
+			push @all_gt, ( defined $gt->{$key} ? $gt->{$key} : "");
+		}
+		$tot_str = $tot_str.join(":", @all_gt)."\t";
+	}
+	$tot_str = $tot_str."\n";
+	return $tot_str;
 }


### PR DESCRIPTION
# Description
This is a change to make mitochondrial variants loadable by loqusdb. Loqusdb requires a genotype quality field. 


## Type of change
- [ ] Major change 
- [ ] Minor change
- [x] Patch
- [ ] Documentation

# Checklist:
- [x] My code follows the [style guidelines for NF pipelines at CMD](http://mtlucmds1.lund.skane.se/wiki/doku.php?id=nextflow&s[]=nextflow#code_style_at_cmd)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (Keep an eye on `.nextflow.log` !)
- [x] I have updated the CHANGELOG
- [ ] The latest commit in the master branch is tagged
      with the correct version number

## Patch
- [x] Stub run completes without errors or new warnings
- [x] At least one other person has reviewed and approved my code

## How to test the changes

1. In the split_normalize_mito step, use the ${group}.mutect2.breakmulti.filtered5p.0genotyped.vcf
2. Run the updated filter_mutect2_mito.pl as usual


## Expected outcome
The GQ field should be added to all filtered variants

# Review
# Post-merge
- [ ] The `master` branch has been tagged with the new version number.
