### PR TITLE
Fix sample_id and group_id positions in bqsr_bam_choice tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+### 3.9.6
+* Fix bug where wrong tuple value unpacked as group and sample id in `bqsr` when starting run from bam
+
 ### 3.9.5
 * Fixed faulty if-condition for annotsv, would result in empty annotsv tsv everytime
 

--- a/main.nf
+++ b/main.nf
@@ -109,6 +109,16 @@ bam_choice.into{
 	bam_bqsr_choice;
 	bam_gatk_choice }
 
+// bqsr expects sample_id to come first, instead of group_id
+bam_bqsr_choice.map {
+	input_tuple ->
+	def group_id = input_tuple.get(0)
+	def sample_id = input_tuple.get(1)
+	def bam_path = input_tuple.get(2)
+	def bai_path = input_tuple.get(3)
+	return tuple(sample_id, group_id, bam_path, bai_path)
+}.set{bam_bqsr_choice}
+
 // vcf_choice.into{
 // 	split_cadd_choice;
 // 	split_vep_choice;


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

Fixes #219, fixes #137

`bqsr_bam_choice` input channel is modified before let loose to the actual `bqsr` process. 

Sample id and group id positions are switched in the input tuple, matching the order defined in the process input block.

It's a dirty workaround, but I'm prioritizing getting this fixed quickly over sorting out the sample id, group id order in the processes preceding bsqr.

## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [x] Patch

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [x] Tag the latest commit (vX.Y.Z format)
- [x] Log samples used for testing in the `Verification_samples_log` Excel sheet

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->
## Patch
- [x] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [x] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
