### PR TITLE
Fix inconsistent order of VCFs to SVDB merge between reruns of wgs trios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # CHANGELOG
+### 3.11.2
+* * Ensure that input VCFs are always supplied in the same alphanumeric order to `svdb_merge` when running trio analysis (see [#172](https://github.com/Clinical-Genomics-Lund/nextflow_wgs/issues/172))
 
 ### 3.11.1
 * Add a process to get contamination values from verifybamid2 software.

--- a/main.nf
+++ b/main.nf
@@ -3392,12 +3392,19 @@ process svdb_merge {
 			tiddit = []
 			gatk = []
 
-                        // Order in which VCFs are merged matters when the merged SV
-                        // is annotated with final position/length, which affects 
-                        // artefact matching in loqusdb. //@alkc 2024-10-30
-                        mantaV.sort()
-                        gatkV.sort()
-                        tidditV.sort()
+			/*
+			 Order in which VCFs are merged matters when the merged SV
+			 is annotated with final position/length, which affects
+			 artefact matching in loqusdb.
+
+			 A possibly better way to sort here would be to sort the
+			 file by familial-relation (e.g. always sort proband-mother-father)
+			 this would ensure the same merge-order regardless of sample-id
+			 */
+
+			mantaV = mantaV.collect { it.toString() }.sort()
+			gatkV = gatkV.collect { it.toString() }.sort()
+			tidditV = tidditV.collect { it.toString() }.sort()
 
 			for (i = 1; i <= mantaV.size(); i++) {
 				tmp = mantaV[i-1] + ':manta' + "${i}"

--- a/main.nf
+++ b/main.nf
@@ -3391,6 +3391,14 @@ process svdb_merge {
 			manta = []
 			tiddit = []
 			gatk = []
+
+                        // Order in which VCFs are merged matters when the merged SV
+                        // is annotated with final position/length, which affects 
+                        // artefact matching in loqusdb. //@alkc 2024-10-30
+                        mantaV.sort()
+                        gatkV.sort()
+                        tidditV.sort()
+
 			for (i = 1; i <= mantaV.size(); i++) {
 				tmp = mantaV[i-1] + ':manta' + "${i}"
 				tmp1 = tidditV[i-1] + ':tiddit' + "${i}"
@@ -3403,6 +3411,7 @@ process svdb_merge {
 				tiddit = tiddit + tt
 				gatk = gatk + ct
 			}
+
 			prio = manta + tiddit + gatk
 			prio = prio.join(',')
 			vcfs = vcfs.join(' ')


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

fixes https://github.com/Clinical-Genomics-Lund/nextflow_wgs/issues/216

## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)
- [x] Log samples used for testing in the `Verification_samples_log` Excel sheet

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Patch
- [x] Stub run completes without errors or new warnings
- [x] At least one other person has reviewed and approved my code (not required for trivial changes)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [x] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [x] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
